### PR TITLE
docs: add help resources per Outreach WG action item

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ This is a basic guide for getting started with Electron's codebase and its depen
    5. [`TaskRunner`](chromium/taskrunner.md)
 3. [V8](v8.md)
 4. [Node.js](nodejs.md)
+5. [Halp Guide](help-resources.md)

--- a/help-resources.md
+++ b/help-resources.md
@@ -1,0 +1,19 @@
+# Halp Resources
+Welcome to Electron! 🎉
+
+## ElectronHQ Slack
+The following channels are great places for starting out on Electron:
+* #ask-anything
+* #issue-triage-n-review
+* #random-TIL-code
+
+Individual Working Group channels are a great place to ask specific questions related to each WG or if you have questions on participation.
+* #wg-community-safety
+* #wg-docs-and-tools
+* #wg-outreach
+* #wg-releases
+* #wg-security
+* #wg-upgrades
+* #wg-website
+
+Additionally, you can read further about our [Slack guidelines](https://github.com/electron/governance/blob/master/policy/slack.md).


### PR DESCRIPTION
Action item from Outreach WG meeting on [2019-04-15](https://github.com/electron/governance/blob/master/wg-outreach/meeting-notes/2019-04-01.md#action-items). 
cc @electron/wg-outreach 

This is a starter doc for resources for where to ask questions. Happy to hear more thoughts on how this can be different! 
cc @codebytere 